### PR TITLE
Add tests and logic for prompt list constraints

### DIFF
--- a/PromptLoader/appSettings.json
+++ b/PromptLoader/appSettings.json
@@ -11,6 +11,7 @@
     "guardrails",
     "output"
   ],
+  "ConstrainPromptList": false,
   "PromptsFolder": "Prompts",
   "PromptSetFolder": "PromptSets",
   "SupportedPromptExtensions": [


### PR DESCRIPTION
Introduce unit tests in `PromptLoaderTests.cs` and `PromptSetLoaderTests.cs` to validate the behavior of `LoadPrompts` and `LoadPromptSets` with the `ConstrainPromptList` option. Update `PromptService` to implement prompt loading constraints based on configuration. Modify `appSettings.json` to set a default value for `ConstrainPromptList`.