### PR TITLE
Enhance prompt handling and testing functionality

### DIFF
--- a/PromptLoader/Program.cs
+++ b/PromptLoader/Program.cs
@@ -42,7 +42,7 @@ var prompts = await promptService.LoadPromptsAsync();
 var promptSets = await promptService.LoadPromptSetsAsync();
 
 var refundPromptSet = promptSets["CustomerService"]["Refund"];
-var salesPromptContext = promptService.GetCombinedPrompts(promptSets["Sales"].Root());
+var salesPromptContext = promptService.GetCombinedPrompts(promptSets["Sales"].Root(), promptSets["Root"]["Root"]);
 // This is the GitHub Models format.  
 PromptYml textSummarizePrompt = prompts["sample.prompt"].ToPromptYml();
 

--- a/PromptLoader/appSettings.json
+++ b/PromptLoader/appSettings.json
@@ -17,5 +17,5 @@
   "SupportedPromptExtensions": [
     ".txt", ".prompt", ".yml", ".jinja", ".jinja2", ".prompt.md", ".md"
   ],
-  "PromptSeparator": "\n---\n"
+  "PromptSeparator": "\n{filename}:\n---\n"
 }


### PR DESCRIPTION
- Added `GetCombinedPrompts_PrependsFilenameHeaderOnFirstEntry` test to verify filename header inclusion in combined prompts.
- Modified `GetCombinedPrompts` method to support an optional `rootSet` for fallback and a customizable `separator`.
- Updated `appSettings.json` to use a filename template for `PromptSeparator`, enabling dynamic prompt formatting.
- Adjusted `Program.cs` to pass an additional `root` prompt set for improved prompt retrieval flexibility.