### PR TITLE
Enhance prompt loading functionality and structure

### DIFF
--- a/PromptLoader/Fluent/FileSystemPromptSource.cs
+++ b/PromptLoader/Fluent/FileSystemPromptSource.cs
@@ -17,7 +17,7 @@ namespace PromptLoader.Fluent
         {
             _folder = PathUtils.ResolvePromptPath(folder);
             _cascadeOverride = cascadeOverride;
-            _supportedExtensions = supportedExtensions ?? PathUtils.GetSupportedPromptExtensions();
+            _supportedExtensions = supportedExtensions ?? PathUtils.GetSupportedPromptExtensions(null, null);
         }
 
         public async Task<Dictionary<string, Prompt>> LoadPromptsAsync()


### PR DESCRIPTION
- Modified `FileSystemPromptSource` constructor to use `PathUtils.GetSupportedPromptExtensions` with null parameters for improved flexibility.

- Updated `LoadPromptsAsync` in `PromptContext` to handle loading prompts from both root and subdirectories, including a new method for allowed prompt names.

- Introduced `GetAllowedPromptNames` to encapsulate logic for determining allowed prompt names based on configuration.

- Streamlined `LoadPromptsFromDirectoryAsync` to return prompts directly and adjusted logic for checking allowed names.

- Added `ProcessSubdirectoriesAsync` to manage loading prompts from subdirectories, enhancing prompt organization and inheritance.

- Overall improvements to modularity and clarity of the codebase for better management of file system prompts.